### PR TITLE
Add "About" page with contact details

### DIFF
--- a/content/about.md
+++ b/content/about.md
@@ -1,0 +1,30 @@
++++
++++
+
+## About
+
+Flott is a toolkit for developing motion control software in Rust. Check out the [home page](/) for more information.
+
+Responsible for the content on this website is Hanno Braun. Full contact data:
+
+<table class="about-contact">
+    <tr>
+        <th>Postal Address</th>
+        <td>
+            <p>Hanno Braun</p>
+            <p>Untere Pfarrgasse 19</p>
+            <p>64720 Michelstadt</p>
+            <p>Germany</p>
+        </td>
+    </tr>
+    <tr>
+        <th>Email</th>
+        <td>
+            <a href="mailto:hanno@braun-embedded.com">hanno@braun-embedded.com</a>
+        </td>
+    </tr>
+    <tr>
+        <th>Phone</th>
+        <td>+49 6061 9797508</td>
+    </tr>
+</table>

--- a/sass/base.scss
+++ b/sass/base.scss
@@ -95,3 +95,18 @@ section.news {
         font-weight: bold;
     }
 }
+
+table.about-contact {
+    * {
+        vertical-align: text-top;
+    }
+
+    th {
+        text-align:    right;
+        padding-right: 1em;
+    }
+
+    td p {
+        margin: 0;
+    }
+}

--- a/templates/extend/base.html
+++ b/templates/extend/base.html
@@ -28,6 +28,7 @@
                     <li><a href="/">Home</a></li>
                     <li><a href="/news">News</a></li>
                     <li><a href="https://github.com/flott-motion">GitHub</a></li>
+                    <li><a href="/about">About</a></li>
                 </ul>
             </nav>
         </header>

--- a/templates/page.html
+++ b/templates/page.html
@@ -1,0 +1,5 @@
+{% extends "extend/base.html" %}
+
+{% block main %}
+    {{ page.content | safe }}
+{% endblock main %}


### PR DESCRIPTION
This kind of thing is required in my jurisdiction (Germany). Not sure if
this is required for this page too, as this is hosted by GitHub,
presumably from the US, but better safe than sorry.