### PR TITLE
Sort news by date

### DIFF
--- a/content/news/_index.md
+++ b/content/news/_index.md
@@ -1,4 +1,5 @@
 +++
 template = "news.html"
 page_template = "news-page.html"
+sort_by = "date"
 +++

--- a/templates/news.html
+++ b/templates/news.html
@@ -9,7 +9,7 @@
             <a href="/atom.xml">(Atom feed)</a>
         </header>
         <ol>
-            {% for page in section.pages | reverse -%}
+            {% for page in section.pages -%}
                 <li>
                     <span class="date">{{ page.date }}</span> -
                     <a href="{{ page.path }}">{{ page.title }}</a>


### PR DESCRIPTION
Turns out that "no sorting" is the default, and that it happened to work
for me locally was just chance.