### PR TITLE
Switch to different newsletter form

### DIFF
--- a/templates/include/newsletter-signup.html
+++ b/templates/include/newsletter-signup.html
@@ -1,7 +1,7 @@
 <form
     class="newsletter"
     method="POST"
-    action="https://d1e704b6.sibforms.com/serve/MUIEADjbIyuehho8d6vIAqfOjgzr_NmLvsh-V7dP5BAYYE9tb7H8oTOO94fxJAA0g6rVNb_9ZRoCbbj_k-UBBWSgbcXsUxUu7bGyxjkIeJhLD1ew5fzRMQvv10qlbqns1ieLflH5C8IFwqeZAu4xFxQAcu8-QQAbNIbQDIvVaqM7VvMGYvTOc7HQ3g4mLDegFuDZUsEETCYo-ziQ">
+    action="https://d1e704b6.sibforms.com/serve/MUIEALZF0OPyjxocQTbWo6a3LVUtkwvADBQH-dTDh3lZnaFQt-xAvwS2FdoD-rZRPE5vPSj1xmbB3ssapsbJCnCR5vTzP3aPZE1QpIHkEX6cUBksCYsX9zl4Fg2vPfb_5ojBBS-tFswwYielbWkQiZ8DNviw2wh30zO0wAVKXMjeAM6bWfsSCBM4fWNWMU51IOb8Mx4_5_pBry3y">
 
     <h3>Monthly Newsletter</h3>
     <p>


### PR DESCRIPTION
The old one used a final confirmation page in German. Now everything
should be in English, or at least the user's selected language (I'm not
perfectly clear on how it works).